### PR TITLE
New functionality: record screen

### DIFF
--- a/Permissions/permissions/commands.py
+++ b/Permissions/permissions/commands.py
@@ -78,11 +78,23 @@ class KillAppCommand(BaseCommand):
 
 
 class TakeScreenshotCommand(BaseCommand):
-    command = 'adb shell screencap /sdcard/screen.png'
+    command = 'adb shell screencap {path}'
+    command_params = ['path', ]
+
+
+class RecordScreenCommand(BaseCommand):
+    command = 'adb shell screenrecord {path}'
+    command_params = ['path', ]
+
+
+class KillallCommand(BaseCommand):
+    command = 'killall {process_name}'
+    command_params = ['process_name', ]
 
 
 class SaveOnComputerCommand(BaseCommand):
-    command = 'adb pull /sdcard/screen.png'
+    command = 'adb pull {path}'
+    command_params = ['path', ]
 
 
 class InstallAppCommand(BaseCommand):

--- a/Permissions/permissions/logging.json
+++ b/Permissions/permissions/logging.json
@@ -19,7 +19,7 @@
             "class": "logging.handlers.RotatingFileHandler",
             "level": "DEBUG",
             "formatter": "simple",
-            "filename": "debug.log",
+            "filename": "/tmp/debug.log",
             "maxBytes": 10485760,
             "backupCount": 20,
             "encoding": "utf8"
@@ -29,7 +29,7 @@
             "class": "logging.handlers.RotatingFileHandler",
             "level": "INFO",
             "formatter": "simple",
-            "filename": "info.log",
+            "filename": "/tmp/info.log",
             "maxBytes": 10485760,
             "backupCount": 20,
             "encoding": "utf8"
@@ -39,7 +39,7 @@
             "class": "logging.handlers.RotatingFileHandler",
             "level": "ERROR",
             "formatter": "simple",
-            "filename": "errors.log",
+            "filename": "/tmp/errors.log",
             "maxBytes": 10485760,
             "backupCount": 20,
             "encoding": "utf8"


### PR DESCRIPTION
### New functionality: start/stop screen recording
New commands allow start and stop screen recording. In combination with existing ones now you can chain commands to i.e. start recording, wait some time, stop recording and pull the footage out from the device.

#### Improvements
- Logs are no longer stored by default in the package directory. You can find them in `/tmp/`
- Fixed issue with parameters in `TakeScreenshotCommand` and `SaveOnComputerCommand`